### PR TITLE
Plastic: fixed isThisWeek, added isThisMonth and isThisYear

### DIFF
--- a/docs/Plastic.md
+++ b/docs/Plastic.md
@@ -27,7 +27,9 @@ The `Plastic` class extends PHP's native `DateTime` class, providing additional,
 - [isToday()](#isToday)  Checks if the date is today.
 - [isTomorrow()](#isTomorrow)  Checks if the date is tomorrow.
 - [isYesterday()](#isYesterday)  Checks if the date is yesterday.
-- [isWeekend()](#isWeekend)  Checks if the date is a weekend.
+- [isThisWeek()](#isThisWeek)  Checks if the date is this week.
+- [isThisMonth()](#isThisMonth)  Checks if the date is this month.
+- [isThisYear()](#isThisYear)  Checks if the date is this year.
 - [lt()](#lt)  Checks if the date is less than another date.
 - [gt()](#gt)  Checks if the date is greater than another date.
 - [isInBetween()](#isInBetween)  Checks if the date is in between two other dates.

--- a/src/Plastic.php
+++ b/src/Plastic.php
@@ -133,7 +133,7 @@ class Plastic extends DateTime
      */
     public function diffInMinutes(DateTimeInterface $date, bool $absolute = true): int
     {
-        return (int) ($this->diffInSeconds($date, $absolute) / 60);
+        return (int)($this->diffInSeconds($date, $absolute) / 60);
     }
 
     /**
@@ -145,7 +145,7 @@ class Plastic extends DateTime
      */
     public function diffInHours(DateTimeInterface $date, bool $absolute = true): int
     {
-        return (int) ($this->diffInMinutes($date, $absolute) / 60);
+        return (int)($this->diffInMinutes($date, $absolute) / 60);
     }
 
     /**
@@ -157,7 +157,7 @@ class Plastic extends DateTime
      */
     public function diffInDays(DateTimeInterface $date, bool $absolute = true): int
     {
-        return (int) $this->diff($date)->format("%a");
+        return (int)$this->diff($date)->format("%a");
     }
 
     /**
@@ -278,6 +278,26 @@ class Plastic extends DateTime
     public function isThisWeek(): bool
     {
         return $this->startOfWeek() <= $this && $this->endOfWeek() >= $this;
+    }
+
+    /**
+     * Check if the current instance is this month
+     *
+     * @return bool True if this is this month, false otherwise.
+     */
+    public function isThisMonth(): bool
+    {
+        return $this->startOfMonth() <= $this && $this->endOfMonth() >= $this;
+    }
+
+    /**
+     * Check if the current instance is this year
+     *
+     * @return bool True if this is this year, false otherwise.
+     */
+    public function isThisYear(): bool
+    {
+        return $this->startOfYear() <= $this && $this->endOfYear() >= $this;
     }
 
     /**

--- a/src/Plastic.php
+++ b/src/Plastic.php
@@ -277,7 +277,13 @@ class Plastic extends DateTime
      */
     public function isThisWeek(): bool
     {
-        return $this->startOfWeek() <= $this && $this->endOfWeek() >= $this;
+        $startOfWeekPlastic = new static();
+        $startOfWeekPlastic->startOfWeek()->startOfDay();
+
+        $endOfWeekPlastic = new static();
+        $endOfWeekPlastic->endOfWeek()->endOfDay();
+
+        return $startOfWeekPlastic <= $this && $endOfWeekPlastic >= $this;
     }
 
     /**
@@ -287,7 +293,13 @@ class Plastic extends DateTime
      */
     public function isThisMonth(): bool
     {
-        return $this->startOfMonth() <= $this && $this->endOfMonth() >= $this;
+        $startOfMonthPlastic = new static();
+        $startOfMonthPlastic->startOfMonth()->startOfDay();
+
+        $endOfMonthPlastic = new static();
+        $endOfMonthPlastic->endOfMonth()->endOfDay();
+
+        return $startOfMonthPlastic <= $this && $endOfMonthPlastic >= $this;
     }
 
     /**
@@ -297,7 +309,13 @@ class Plastic extends DateTime
      */
     public function isThisYear(): bool
     {
-        return $this->startOfYear() <= $this && $this->endOfYear() >= $this;
+        $startOfYearPlastic = new static();
+        $startOfYearPlastic->startOfYear()->startOfDay();
+
+        $endOfYearPlastic = new static();
+        $endOfYearPlastic->endOfYear()->endOfDay();
+
+        return $startOfYearPlastic <= $this && $endOfYearPlastic >= $this;
     }
 
     /**

--- a/src/Plastic.php
+++ b/src/Plastic.php
@@ -277,13 +277,7 @@ class Plastic extends DateTime
      */
     public function isThisWeek(): bool
     {
-        $startOfWeekPlastic = new static();
-        $startOfWeekPlastic->startOfWeek()->startOfDay();
-
-        $endOfWeekPlastic = new static();
-        $endOfWeekPlastic->endOfWeek()->endOfDay();
-
-        return $startOfWeekPlastic <= $this && $endOfWeekPlastic >= $this;
+        return (new static())->startOfWeek()->startOfDay() <= $this && (new static())->endOfWeek()->endOfDay() >= $this;
     }
 
     /**
@@ -293,13 +287,7 @@ class Plastic extends DateTime
      */
     public function isThisMonth(): bool
     {
-        $startOfMonthPlastic = new static();
-        $startOfMonthPlastic->startOfMonth()->startOfDay();
-
-        $endOfMonthPlastic = new static();
-        $endOfMonthPlastic->endOfMonth()->endOfDay();
-
-        return $startOfMonthPlastic <= $this && $endOfMonthPlastic >= $this;
+        return (new static())->startOfMonth()->startOfDay() <= $this && (new static())->endOfMonth()->endOfDay() >= $this;
     }
 
     /**
@@ -309,13 +297,7 @@ class Plastic extends DateTime
      */
     public function isThisYear(): bool
     {
-        $startOfYearPlastic = new static();
-        $startOfYearPlastic->startOfYear()->startOfDay();
-
-        $endOfYearPlastic = new static();
-        $endOfYearPlastic->endOfYear()->endOfDay();
-
-        return $startOfYearPlastic <= $this && $endOfYearPlastic >= $this;
+        return (new static())->startOfYear()->startOfDay() <= $this && (new static())->endOfYear()->endOfDay() >= $this;
     }
 
     /**

--- a/tests/Unit/PlasticTest.php
+++ b/tests/Unit/PlasticTest.php
@@ -131,6 +131,30 @@ class PlasticTest extends TestCase
         $this->assertTrue($endOfWeek->isThisWeek());
     }
 
+    public function testIsThisMonth(): void
+    {
+        $now = new Plastic();
+        $this->assertTrue($now->isThisMonth());
+
+        $startOfMonth = $now->startOfMonth();
+        $this->assertTrue($startOfMonth->isThisMonth());
+
+        $endOfMonth = $now->endOfMonth();
+        $this->assertTrue($endOfMonth->isThisMonth());
+    }
+
+    public function testIsThisYear(): void
+    {
+        $now = new Plastic();
+        $this->assertTrue($now->isThisYear());
+
+        $startOfYear = $now->startOfYear();
+        $this->assertTrue($startOfYear->isThisYear());
+
+        $endOfYear = $now->endOfYear();
+        $this->assertTrue($endOfYear->isThisYear());
+    }
+
     public function testIsInBetween(): void
     {
         $start = new Plastic('2024-01-01');

--- a/tests/Unit/PlasticTest.php
+++ b/tests/Unit/PlasticTest.php
@@ -129,6 +129,14 @@ class PlasticTest extends TestCase
 
         $endOfWeek = $now->endOfWeek();
         $this->assertTrue($endOfWeek->isThisWeek());
+
+        $nextWeek = new Plastic();
+        $nextWeek->addDays(7);
+        $this->assertFalse($nextWeek->isThisWeek());
+
+        $lastWeek = new Plastic();
+        $lastWeek->subDays(7);
+        $this->assertFalse($lastWeek->isThisWeek());
     }
 
     public function testIsThisMonth(): void
@@ -141,6 +149,14 @@ class PlasticTest extends TestCase
 
         $endOfMonth = $now->endOfMonth();
         $this->assertTrue($endOfMonth->isThisMonth());
+
+        $nextMonth = new Plastic();
+        $nextMonth->addDays(35);
+        $this->assertFalse($nextMonth->isThisMonth());
+
+        $lastMonth = new Plastic();
+        $lastMonth->subDays(35);
+        $this->assertFalse($lastMonth->isThisMonth());
     }
 
     public function testIsThisYear(): void
@@ -153,6 +169,14 @@ class PlasticTest extends TestCase
 
         $endOfYear = $now->endOfYear();
         $this->assertTrue($endOfYear->isThisYear());
+
+        $nextYear = new Plastic();
+        $nextYear->addDays(366);
+        $this->assertFalse($nextYear->isThisYear());
+
+        $lastYear = new Plastic();
+        $lastYear->subDays(366);
+        $this->assertFalse($lastYear->isThisYear());
     }
 
     public function testIsInBetween(): void


### PR DESCRIPTION
The `isThisWeek` method used to always return `true` because it modified $this while checking.